### PR TITLE
Read perturbative order from theory card for vrap

### DIFF
--- a/pinefarm/external/vrap.py
+++ b/pinefarm/external/vrap.py
@@ -29,7 +29,7 @@ from .. import configs, install
 from . import interface
 
 _PINEAPPL = "test.pineappl.lz4"
-VERSION = "1.2"
+VERSION = "1.3"
 _POSITIVITY_PDFS = {
     "pos_ddb": [1, -1, 21],
     "pos_uub": [2, -2, 21],

--- a/pinefarm/external/vrap.py
+++ b/pinefarm/external/vrap.py
@@ -16,6 +16,7 @@
 """
 import subprocess as sp
 import tempfile
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -121,6 +122,11 @@ class Vrap(interface.External):
             pdfname = yaml_dict["positivity_pdf"]
             gen_pos_pdf(pdfname)
             self.pdf = pdfname
+            if vrap_order != "NLO":
+                warnings.warn("Positivity DY observables are only computed at NLO")
+                vrap_order = "NLO"
+
+
 
         yaml_to_vrapcard(yaml_dict, self.pdf, self._input_card, order=vrap_order)
 


### PR DESCRIPTION
NNLO is now implemented in vrap: https://github.com/NNPDF/hawaiian_vrap/pull/21

In order to enable in the `pinefarm` I've  modified the runner for vrap so that the order computed is the order given by the runcard.

The positivity grids instead can only be computed at NLO at the moment because I cannot think of any tricks that wouldn't mean rewriting half of vrap :(